### PR TITLE
APII-2826: staging endpoint wrong in README

### DIFF
--- a/code/dce-downloader/README.MD
+++ b/code/dce-downloader/README.MD
@@ -18,7 +18,7 @@ For each of the reference tools, the following prerequisites apply:
     {
         "passkey": "your_passkey_here",
         "secret": "your_secret_key_here",
-        "url" : "https://stg-api.bazaarvoice.com/dce/v3/data"
+        "url" : "https://stg.api.bazaarvoice.com/dce/v3/data"
     },
 "prod":
     {

--- a/code/dce-downloader/config.json.example
+++ b/code/dce-downloader/config.json.example
@@ -3,7 +3,7 @@
     {
         "passkey": "your_passkey_here",
         "secret": "your_secret_key_here",
-        "url" : "https://stg-api.bazaarvoice.com/dce/v3/data"
+        "url" : "https://stg.api.bazaarvoice.com/dce/v3/data"
     },
 "prod":
     {


### PR DESCRIPTION
  - Update README and config.json.example with correct stg URL