### PR TITLE
APII-2824: dce.js does not correctly download gz files

### DIFF
--- a/code/dce-downloader/node/dce-common.js
+++ b/code/dce-downloader/node/dce-common.js
@@ -80,7 +80,10 @@ module.exports = {
       maxRedirects: 2,
       headers: this.buildBVHeaders(passkey, signature, timestamp),
       qs: path ? { path: path } : {},
-      resolveWithFullResponse: true
+      resolveWithFullResponse: true,
+
+      // If we're getting a gz file from DCE, we need to preserve it as binary
+      encoding : path && path.includes('gz') ? null : 'utf-8'
     });
 
   },

--- a/code/dce-downloader/node/dce.js
+++ b/code/dce-downloader/node/dce.js
@@ -49,9 +49,11 @@ dce.doHttpGet(environment.url, environment.passkey, environment.secret, path)
       // gzip-style decompression
       zlib.gunzip(response.body, function (err, result) {
         if (err) {
-          console.log(response.body);
+            console.log('could not gunzip');
         } else {
-          console.log(JSON.stringify(result, null, 4));
+            // Body was an octet stream. We need to convert result to String
+            // then do a JSON stringify.
+            console.log(JSON.stringify(result.toString(), null, 4));
         }
       });
 


### PR DESCRIPTION
  - Use encoding:null when path to download is a gz file (to prevent request from making a String object)